### PR TITLE
FIX: Atomically store files in CAS

### DIFF
--- a/serve/file_handler.go
+++ b/serve/file_handler.go
@@ -26,7 +26,7 @@ func (handler *FileHandler) handlePut(ctx *fasthttp.RequestCtx) error {
 		return err
 	}
 	ctx.SetBodyString(strHash)
-	utils.LogInfo("Successfully stored file.", zap.String("hash", fmt.Sprintf("%x", hash)))
+	utils.LogDebug("Successfully stored file.", zap.String("hash", fmt.Sprintf("%x", hash)))
 	return nil
 }
 


### PR DESCRIPTION
This change ensures that files are stored in CAS atomically by saving
these files with a random temporary path before actually moving them to
where they belong.